### PR TITLE
Update systemd to use bonefire_env

### DIFF
--- a/systemd/bonfire-flask.service
+++ b/systemd/bonfire-flask.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/opt/bonfire
-ExecStart=/usr/bin/env python3 /opt/bonfire/bonfire_flask.py
+ExecStart=/opt/bonfire/bonefire_env/bin/python /opt/bonfire/bonfire_flask.py
 Restart=always
 
 [Install]

--- a/systemd/bonfire-logger.service
+++ b/systemd/bonfire-logger.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/opt/bonfire
-ExecStart=/usr/bin/env python3 /opt/bonfire/bonfire_logger.py
+ExecStart=/opt/bonfire/bonefire_env/bin/python /opt/bonfire/bonfire_logger.py
 Restart=always
 
 [Install]

--- a/systemd/bonfire-tunnel.service
+++ b/systemd/bonfire-tunnel.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/opt/bonfire
-ExecStart=/usr/bin/env python3 /opt/bonfire/bonfire_tunnel.py
+ExecStart=/opt/bonfire/bonefire_env/bin/python /opt/bonfire/bonfire_tunnel.py
 Restart=always
 
 [Install]


### PR DESCRIPTION
## Summary
- use `bonefire_env`'s Python interpreter for systemd services

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845d2c384d083249ba1da441a3fea34